### PR TITLE
Previously selected claims should be selected when App opens

### DIFF
--- a/genstudio-mlr-claims-app/src/genstudiopem/web-src/src/components/AdditionalContextDialog.tsx
+++ b/genstudio-mlr-claims-app/src/genstudiopem/web-src/src/components/AdditionalContextDialog.tsx
@@ -32,6 +32,25 @@ export default function AdditionalContextDialog(): JSX.Element {
     })();
   }, []);
 
+  useEffect(() => {
+    (async () => {
+      if (guestConnection) {
+        const generationContext = await GenerationContextService.getGenerationContext(guestConnection);
+        if (generationContext?.additionalContexts) {
+          const contextValues = Object.values(generationContext.additionalContexts).flat();
+          const appClaims = contextValues.find(ctx => 
+            ctx.extensionId === extensionId && 
+            ctx.additionalContextType === AdditionalContextTypes.Claims
+          );
+          
+          if (appClaims && Array.isArray(appClaims.additionalContextValues)) {
+            setSelectedClaims(appClaims.additionalContextValues);
+          }
+        }
+      }
+    })();
+  }, [guestConnection]);
+
   const handleClaimsLibrarySelection = (library: Key | null) => {
     if (library === null) return;
     setSelectedClaimLibrary(library);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

If an add-on was used to select claims, when we opened the dialog another time, the previously selected claims were not automatically selected.

This change uses the new getGenerationContext hook to fetch the context, and pre-select the old claims.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.