### PR TITLE
Add E2E test environments to External DAM app

### DIFF
--- a/.github/workflows/pr-genstudio-external-dam-app.yaml
+++ b/.github/workflows/pr-genstudio-external-dam-app.yaml
@@ -11,5 +11,5 @@ jobs:
     uses: ./.github/workflows/aio-app-template.yml
     with:
       app: genstudio-external-dam-app
-      environment: '["Genstudio Engineering 01 - genstudio-external-dam-app - workspace Stage", "GenStudio GA PAT04 - genstudio-external-dam-app - workspace Stage"]'
+      environment: '["Genstudio Engineering 01 - genstudio-external-dam-app - workspace Stage", "GenStudio GA PAT04 - genstudio-external-dam-app - workspace Stage", "GenStudio Internal - E2E Tests - genstudio-external-dam-app - workspace Stage", "GenStudio Internal - E2E Tests - genstudio-external-dam-app - workspace Production"]'
     secrets: inherit


### PR DESCRIPTION
## Description

Add stage and prod envs, for E2E testing envs, to the External DAM App example's workflow yaml:

- GenStudio Internal - E2E Tests - genstudio-external-dam-app - workspace Stage
- GenStudio Internal - E2E Tests - genstudio-external-dam-app - workspace Production

## Related Issue

N/A

## Motivation and Context

Allows publishing of External DAM App to E2E testing env.

## How Has This Been Tested?

N/A

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.