### PR TITLE
GS-16405 feat: Use new asset fields

### DIFF
--- a/genstudio-external-dam-app/package-lock.json
+++ b/genstudio-external-dam-app/package-lock.json
@@ -12,7 +12,7 @@
         "@adobe/aio-lib-files": "^4.1.0",
         "@adobe/aio-sdk": "^6",
         "@adobe/generator-add-action-generic": "^1.0.1",
-        "@adobe/genstudio-extensibility-sdk": "^2.2.1",
+        "@adobe/genstudio-extensibility-sdk": "^2.3.0",
         "@adobe/react-spectrum": "^3.4.0",
         "@adobe/uix-guest": "^1.0.0",
         "@aws-sdk/client-s3": "^3.777.0",
@@ -2772,9 +2772,9 @@
       }
     },
     "node_modules/@adobe/genstudio-extensibility-sdk": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@adobe/genstudio-extensibility-sdk/-/genstudio-extensibility-sdk-2.2.1.tgz",
-      "integrity": "sha512-iEULQa08hp1glRoMS9e+0FDT705UH+tApAX/0Amaa3VPYTLW2Ld2GWrRrvBLyWG8QIT/dgM3nk/+xluV58B0Hg==",
+      "version": "2.3.0",
+      "resolved": "https://artifactory.corp.adobe.com/artifactory/api/npm/npm-adobe-platform-release/@adobe/genstudio-extensibility-sdk/-/genstudio-extensibility-sdk-2.3.0.tgz",
+      "integrity": "sha512-5I3dM2fRf3zddVtVvnD4wvtBnHIxfTuT9YfrC5FmBGpsM8PKl8zo2r4mHtll+DTYlPBPTkL+mBzmXhDPP/xy+Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/uix-core": "^1.0.0",

--- a/genstudio-external-dam-app/package-lock.json
+++ b/genstudio-external-dam-app/package-lock.json
@@ -17020,7 +17020,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/genstudio-external-dam-app/package-lock.json
+++ b/genstudio-external-dam-app/package-lock.json
@@ -2773,7 +2773,7 @@
     },
     "node_modules/@adobe/genstudio-extensibility-sdk": {
       "version": "2.3.0",
-      "resolved": "https://artifactory.corp.adobe.com/artifactory/api/npm/npm-adobe-platform-release/@adobe/genstudio-extensibility-sdk/-/genstudio-extensibility-sdk-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/@adobe/genstudio-extensibility-sdk/-/genstudio-extensibility-sdk-2.3.0.tgz",
       "integrity": "sha512-5I3dM2fRf3zddVtVvnD4wvtBnHIxfTuT9YfrC5FmBGpsM8PKl8zo2r4mHtll+DTYlPBPTkL+mBzmXhDPP/xy+Q==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -17020,6 +17020,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/genstudio-external-dam-app/package.json
+++ b/genstudio-external-dam-app/package.json
@@ -7,7 +7,7 @@
     "@adobe/aio-lib-files": "^4.1.0",
     "@adobe/aio-sdk": "^6",
     "@adobe/generator-add-action-generic": "^1.0.1",
-    "@adobe/genstudio-extensibility-sdk": "^2.2.1",
+    "@adobe/genstudio-extensibility-sdk": "^2.3.0",
     "@adobe/react-spectrum": "^3.4.0",
     "@adobe/uix-guest": "^1.0.0",
     "@aws-sdk/client-s3": "^3.777.0",

--- a/genstudio-external-dam-app/src/genstudiopem/web-src/src/components/AssetViewer.tsx
+++ b/genstudio-external-dam-app/src/genstudiopem/web-src/src/components/AssetViewer.tsx
@@ -22,7 +22,7 @@ import {
 import AssetCard from "./AssetCard";
 import AssetTypeFilter from "./AssetTypeFilter";
 import { useAssetActions } from "../hooks/useAssetActions";
-import { extensionId } from "../Constants";
+import { extensionId, extensionLabel, ICON_DATA_URI } from "../Constants";
 import { Asset, ExtensionRegistrationService } from "@adobe/genstudio-extensibility-sdk";
 import { attach } from "@adobe/uix-guest";
 import { DamAsset } from "../types";
@@ -63,8 +63,10 @@ export default function AssetViewer(): JSX.Element {
       id: asset.id,
       name: asset.name,
       signedUrl: asset.url,
-      source: "S3",
+      source: extensionLabel,
       sourceUrl: asset.url,
+      extensionId: extensionId,
+      iconUrl: ICON_DATA_URI,
     };
   };
 


### PR DESCRIPTION
Update `Asset` values returned by `convertToGenStudioAsset`.

## Description

Replace hardcoded `source` ("S3") with `extensionLabel` from Constants file.
Add values for new `extensionId` and `iconUrl` added to `Asset` type.

## Related Issue

https://github.com/adobe/genstudio-extensibility-sdk/pull/49

## Motivation and Context

Extension ID is required in the new `Asset` type.

Extension ID will be used to re-toggle selected assets on re-opening to asset selector dialog.
Icon URL will be used to show an icon of the asset's source in the asset details page.

## How Has This Been Tested?

Locally added the updated `genstudio-extensibility-sdk` (from this PR: https://github.com/adobe/genstudio-extensibility-sdk/pull/49) to the `genstudio-external-dam-app` example app in this repo, then verified that the values for `externalAssetSource`, `externalAssetExtensionId`, and `externalAssetIconUrl` were all populated in the asset object, when an asset was selected and imported in the app.

## Screenshots (if appropriate):

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.