### PR TITLE
ci: declare workflow-level `contents: read` on 10 workflows

### DIFF
--- a/.github/workflows/main-genstudio-create-validation.yaml
+++ b/.github/workflows/main-genstudio-create-validation.yaml
@@ -8,6 +8,9 @@ on:
       - "genstudio-create-validation/**"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     uses: ./.github/workflows/aio-app-template.yml

--- a/.github/workflows/main-genstudio-external-dam-app.yaml
+++ b/.github/workflows/main-genstudio-external-dam-app.yaml
@@ -8,6 +8,9 @@ on:
       - "genstudio-external-dam-app/**"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     uses: ./.github/workflows/aio-app-template.yml

--- a/.github/workflows/main-genstudio-external-template-app.yaml
+++ b/.github/workflows/main-genstudio-external-template-app.yaml
@@ -8,6 +8,9 @@ on:
       - "genstudio-external-template-app/**"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     uses: ./.github/workflows/aio-app-template.yml

--- a/.github/workflows/main-genstudio-mlr-claims-app.yaml
+++ b/.github/workflows/main-genstudio-mlr-claims-app.yaml
@@ -8,6 +8,9 @@ on:
       - "genstudio-mlr-claims-app/**"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     uses: ./.github/workflows/aio-app-template.yml

--- a/.github/workflows/main-genstudio-translation-extension.yaml
+++ b/.github/workflows/main-genstudio-translation-extension.yaml
@@ -8,6 +8,9 @@ on:
       - "genstudio-translation-extension/**"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     uses: ./.github/workflows/aio-app-template.yml

--- a/.github/workflows/pr-genstudio-create-validation.yaml
+++ b/.github/workflows/pr-genstudio-create-validation.yaml
@@ -6,6 +6,9 @@ on:
       - "genstudio-create-validation/**"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   pr:
     uses: ./.github/workflows/aio-app-template.yml

--- a/.github/workflows/pr-genstudio-external-dam-app.yaml
+++ b/.github/workflows/pr-genstudio-external-dam-app.yaml
@@ -6,6 +6,9 @@ on:
       - "genstudio-external-dam-app/**"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   pr:
     uses: ./.github/workflows/aio-app-template.yml

--- a/.github/workflows/pr-genstudio-external-template-app.yaml
+++ b/.github/workflows/pr-genstudio-external-template-app.yaml
@@ -6,6 +6,9 @@ on:
       - "genstudio-external-template-app/**"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   pr:
     uses: ./.github/workflows/aio-app-template.yml

--- a/.github/workflows/pr-genstudio-mlr-claims-app.yaml
+++ b/.github/workflows/pr-genstudio-mlr-claims-app.yaml
@@ -6,6 +6,9 @@ on:
       - "genstudio-mlr-claims-app/**"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   pr:
     uses: ./.github/workflows/aio-app-template.yml

--- a/.github/workflows/pr-genstudio-translation-extension.yaml
+++ b/.github/workflows/pr-genstudio-translation-extension.yaml
@@ -6,6 +6,9 @@ on:
       - "genstudio-translation-extension/**"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   pr:
     uses: ./.github/workflows/aio-app-template.yml


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on 10 workflows in `.github/workflows/` that don't call a GitHub API beyond the initial checkout.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. Pinning per workflow caps runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.