### PR TITLE
add body and headline update actions in e2e validation panel

### DIFF
--- a/genstudio-e2e-app/src/genstudiopem/web-src/src/components/Validation.tsx
+++ b/genstudio-e2e-app/src/genstudiopem/web-src/src/components/Validation.tsx
@@ -35,6 +35,23 @@ const jsonBoxStyle: React.CSSProperties = {
   wordBreak: "break-all",
 };
 
+function resolveBodyFieldName(experience: Experience | null): string {
+  if (!experience?.experienceFields) {
+    return "body";
+  }
+
+  const fieldNames = Object.values(experience.experienceFields)
+    .map((field) => field.fieldName)
+    .filter(Boolean);
+
+  const preferredBodyField =
+    fieldNames.find((name) => /^body$/i.test(name)) ||
+    fieldNames.find((name) => /(^|_)body$/i.test(name)) ||
+    fieldNames.find((name) => /content/i.test(name));
+
+  return preferredBodyField || "body";
+}
+
 export default function Validation(): React.JSX.Element {
   const guestConnection = useGuestConnection(EXTENSION_ID);
   const [experiences, setExperiences] = useState<Experience[]>([]);
@@ -118,14 +135,15 @@ export default function Validation(): React.JSX.Element {
         type="button"
         data-testid="update-field-submit"
         disabled={experiences.length === 0}
-        onClick={() => {
+        onClick={async () => {
           if (!guestConnection || experiences.length === 0) return;
+
           const update: FieldUpdate = {
             experienceId: experiences[0].id,
             name: "subject",
             value: "E2E Updated Subject",
           };
-          ValidationExtensionService.updateField(guestConnection, update);
+          await ValidationExtensionService.updateField(guestConnection, update);
           setLastUpdate(update);
         }}
         style={{
@@ -140,6 +158,68 @@ export default function Validation(): React.JSX.Element {
         }}
       >
         Update Subject
+      </button>
+
+      <button
+        type="button"
+        data-testid="update-body-submit"
+        disabled={experiences.length === 0}
+        onClick={async () => {
+          if (!guestConnection || experiences.length === 0) return;
+
+          const targetExperience = experiences[0];
+
+          const update: FieldUpdate = {
+            experienceId: targetExperience.id,
+            name: resolveBodyFieldName(targetExperience),
+            value: "E2E Updated Body",
+          };
+          await ValidationExtensionService.updateField(guestConnection, update);
+          setLastUpdate(update);
+        }}
+        style={{
+          marginTop: "8px",
+          marginLeft: "8px",
+          padding: "8px 24px",
+          background: "#1473E6",
+          color: "#fff",
+          border: "none",
+          borderRadius: "4px",
+          cursor: "pointer",
+          fontSize: "14px",
+        }}
+      >
+        Update Body
+      </button>
+
+      <button
+        type="button"
+        data-testid="update-headline-submit"
+        disabled={experiences.length === 0}
+        onClick={async () => {
+          if (!guestConnection || experiences.length === 0) return;
+
+          const update: FieldUpdate = {
+            experienceId: experiences[0].id,
+            name: "headline",
+            value: "E2E Updated Headline",
+          };
+          await ValidationExtensionService.updateField(guestConnection, update);
+          setLastUpdate(update);
+        }}
+        style={{
+          marginTop: "8px",
+          marginLeft: "8px",
+          padding: "8px 24px",
+          background: "#1473E6",
+          color: "#fff",
+          border: "none",
+          borderRadius: "4px",
+          cursor: "pointer",
+          fontSize: "14px",
+        }}
+      >
+        Update Headline
       </button>
 
       {lastUpdate && (

--- a/genstudio-e2e-app/src/genstudiopem/web-src/src/components/Validation.tsx
+++ b/genstudio-e2e-app/src/genstudiopem/web-src/src/components/Validation.tsx
@@ -35,22 +35,31 @@ const jsonBoxStyle: React.CSSProperties = {
   wordBreak: "break-all",
 };
 
-function resolveBodyFieldName(experience: Experience | null): string {
-  if (!experience?.experienceFields) {
-    return "body";
-  }
+const updateButtonStyle: React.CSSProperties = {
+  marginTop: "8px",
+  padding: "8px 24px",
+  background: "#1473E6",
+  color: "#fff",
+  border: "none",
+  borderRadius: "4px",
+  cursor: "pointer",
+  fontSize: "14px",
+};
 
-  const fieldNames = Object.values(experience.experienceFields)
-    .map((field) => field.fieldName)
-    .filter(Boolean);
-
-  const preferredBodyField =
-    fieldNames.find((name) => /^body$/i.test(name)) ||
-    fieldNames.find((name) => /(^|_)body$/i.test(name)) ||
-    fieldNames.find((name) => /content/i.test(name));
-
-  return preferredBodyField || "body";
-}
+const FIELD_UPDATE_CONFIG = [
+  {
+    testId: "update-field-submit",
+    label: "Update Subject",
+    fieldName: "subject",
+    fieldValue: "E2E Updated Subject",
+  },
+  {
+    testId: "update-headline-submit",
+    label: "Update Headline",
+    fieldName: "headline",
+    fieldValue: "E2E Updated Headline",
+  },
+] as const;
 
 export default function Validation(): React.JSX.Element {
   const guestConnection = useGuestConnection(EXTENSION_ID);
@@ -58,6 +67,21 @@ export default function Validation(): React.JSX.Element {
   const [generationContext, setGenerationContext] = useState<GenerationContext | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [lastUpdate, setLastUpdate] = useState<FieldUpdate | null>(null);
+
+  const handleFieldUpdate = async (
+    fieldName: string,
+    fieldValue: string,
+  ): Promise<void> => {
+    if (!guestConnection || experiences.length === 0) return;
+
+    const update: FieldUpdate = {
+      experienceId: experiences[0].id,
+      name: fieldName,
+      value: fieldValue,
+    };
+    await ValidationExtensionService.updateField(guestConnection, update);
+    setLastUpdate(update);
+  };
 
   useEffect(() => {
     if (!guestConnection) return;
@@ -131,96 +155,21 @@ export default function Validation(): React.JSX.Element {
       </button>
 
       <h4>Update Field</h4>
-      <button
-        type="button"
-        data-testid="update-field-submit"
-        disabled={experiences.length === 0}
-        onClick={async () => {
-          if (!guestConnection || experiences.length === 0) return;
-
-          const update: FieldUpdate = {
-            experienceId: experiences[0].id,
-            name: "subject",
-            value: "E2E Updated Subject",
-          };
-          await ValidationExtensionService.updateField(guestConnection, update);
-          setLastUpdate(update);
-        }}
-        style={{
-          marginTop: "8px",
-          padding: "8px 24px",
-          background: "#1473E6",
-          color: "#fff",
-          border: "none",
-          borderRadius: "4px",
-          cursor: "pointer",
-          fontSize: "14px",
-        }}
-      >
-        Update Subject
-      </button>
-
-      <button
-        type="button"
-        data-testid="update-body-submit"
-        disabled={experiences.length === 0}
-        onClick={async () => {
-          if (!guestConnection || experiences.length === 0) return;
-
-          const targetExperience = experiences[0];
-
-          const update: FieldUpdate = {
-            experienceId: targetExperience.id,
-            name: resolveBodyFieldName(targetExperience),
-            value: "E2E Updated Body",
-          };
-          await ValidationExtensionService.updateField(guestConnection, update);
-          setLastUpdate(update);
-        }}
-        style={{
-          marginTop: "8px",
-          marginLeft: "8px",
-          padding: "8px 24px",
-          background: "#1473E6",
-          color: "#fff",
-          border: "none",
-          borderRadius: "4px",
-          cursor: "pointer",
-          fontSize: "14px",
-        }}
-      >
-        Update Body
-      </button>
-
-      <button
-        type="button"
-        data-testid="update-headline-submit"
-        disabled={experiences.length === 0}
-        onClick={async () => {
-          if (!guestConnection || experiences.length === 0) return;
-
-          const update: FieldUpdate = {
-            experienceId: experiences[0].id,
-            name: "headline",
-            value: "E2E Updated Headline",
-          };
-          await ValidationExtensionService.updateField(guestConnection, update);
-          setLastUpdate(update);
-        }}
-        style={{
-          marginTop: "8px",
-          marginLeft: "8px",
-          padding: "8px 24px",
-          background: "#1473E6",
-          color: "#fff",
-          border: "none",
-          borderRadius: "4px",
-          cursor: "pointer",
-          fontSize: "14px",
-        }}
-      >
-        Update Headline
-      </button>
+      {FIELD_UPDATE_CONFIG.map((config, index) => (
+        <button
+          key={config.testId}
+          type="button"
+          data-testid={config.testId}
+          disabled={experiences.length === 0}
+          onClick={() => handleFieldUpdate(config.fieldName, config.fieldValue)}
+          style={{
+            ...updateButtonStyle,
+            ...(index > 0 ? { marginLeft: "8px" } : {}),
+          }}
+        >
+          {config.label}
+        </button>
+      ))}
 
       {lastUpdate && (
         <div data-testid="last-update-box" style={jsonBoxStyle}>


### PR DESCRIPTION
Extend the validation utility panel with explicit body and headline update buttons, and make field updates await host completion while preserving existing test ids.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.