### PR TITLE
docs: add GenStudio API developer portal link

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ We provide a utility script in the `scripts` directory that helps manage GitHub 
 
 If you're implementing individual workflows for your own extension, this script can help you securely manage deployment secrets without manually entering them in the GitHub UI.
 
+## Resources
+
+- [GenStudio API Developer Portal](https://developer.adobe.com/genstudio-api/) - REST API for integrating with GenStudio for Performance Marketing. Provides the Experience API to retrieve and manage approved Experiences by ID or via paginated/filterable lists, obtain pre-signed asset URLs, and access HTML templates. Uses OAuth Server-to-Server authentication via Adobe Developer Console. Base URL: `https://genstudio.adobe.io`
+
 ## Contributing
 
 Contributions are welcomed! Read the [Contributing Guide](./.github/CONTRIBUTING.md) for more information.

--- a/genstudio-create-validation/README.md
+++ b/genstudio-create-validation/README.md
@@ -1,7 +1,5 @@
 # GenStudio Create Validation - Reference App
 
-dummy
-
 A basic reference application for building **Adobe GenStudio for Performance Marketing validation extensions** without IO Actions.
 
 > 📖 **[See QUICKSTART.md for setup instructions](./QUICKSTART.md)**


### PR DESCRIPTION
## Summary
- Add a **Resources** section to the root `README.md` with a link and description for the [GenStudio API Developer Portal](https://developer.adobe.com/genstudio-api/)
- Remove stray `dummy` placeholder text from `genstudio-create-validation/README.md`

## Test plan
- [ ] Verify links resolve correctly
- [ ] Review README rendering on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)