### PR TITLE
docs: add Fragment Swap Dialog documentation to MLR Claims App README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,7 @@ internal/
 genstudio-extensibility-cli/config/context.yaml
 
 mcp-server.log
+
+# Nested repos and Claude local config
+genstudio-extensibility-examples/
+.claude/

--- a/genstudio-mlr-claims-app/README.md
+++ b/genstudio-mlr-claims-app/README.md
@@ -10,10 +10,58 @@ This example demonstrates a full-featured validation extension with:
 
 - Real-time claims validation against regulatory requirements
 - Multiple claims library support
-- Integration with both validation and prompt extension points
+- Integration with validation, prompt, and fragment swap extension points
 - Experience selection and data display
 
 Use this as a starting point for building compliance validation tools for medical, legal, or regulatory content approval.
+
+## Extension Points
+
+This app registers three extension points:
+
+| Extension Point | Description | Access Location |
+|-----------------|-------------|-----------------|
+| **Prompt Drawer Dialog** | Add context (claims library selection) before content generation | Opens from the prompt input area |
+| **Right Panel Dialog** | Validate generated content against MLR claims | Opens from the validation panel |
+| **Fragment Swap Dialog** | Swap content fragments into experience fields | Opens when editing a field in an experience |
+
+### Fragment Swap Dialog
+
+The Fragment Swap Dialog allows users to replace content in an experience field with pre-approved MLR claims. This is useful when generated content needs to be swapped with compliant, pre-vetted text.
+
+**Required Feature Flags:**
+
+| Feature Flag | Purpose |
+|--------------|---------|
+| `GS-33054_horizon_canvas_content_fragment_swap` | Enables the swap button for experiences on Express or Horizon canvas |
+| `GS-28940_Fragment_Swap_Extension` | Enables extensions to appear in the dropdown after opening the fragment swap dialog |
+
+> ⚠️ Contact your Adobe administrator to enable these feature flags before using the Fragment Swap Dialog.
+
+**How to Access:**
+1. Generate an experience in GenStudio
+2. Click on any editable field (headline, body, CTA, etc.)
+3. Select the "Swap" or "Replace with claim" option
+4. The Fragment Swap Dialog opens, showing:
+   - **Left panel:** Available claims from your configured claim libraries
+   - **Right panel:** Current experience context (fields, brand, product, channel)
+5. Click a claim to select it — the field is highlighted showing which content will be swapped
+6. Confirm to replace the field content with the selected claim
+
+**Key SDK Services Used:**
+```typescript
+import { FragmentSwapExtensionService } from "@adobe/genstudio-extensibility-sdk";
+
+// Get context about the experience and field being edited
+FragmentSwapExtensionService.getExperience(guestConnection);
+FragmentSwapExtensionService.getGenerationContext(guestConnection);
+FragmentSwapExtensionService.getSelectedField(guestConnection);
+
+// Set the replacement value
+FragmentSwapExtensionService.setSwapValue(guestConnection, newValue);
+```
+
+**Customization:** Edit `src/genstudiopem/web-src/src/components/FragmentSwapDialog/index.tsx` to customize the UI, add filtering, or integrate with different content sources.
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary
- Add Extension Points table listing all three extension points (Prompt Drawer, Right Panel, Fragment Swap)
- Document Fragment Swap Dialog with required feature flags
- Include step-by-step access instructions
- Add SDK service code examples for FragmentSwapExtensionService

## Feature Flags Documented
- `GS-33054_horizon_canvas_content_fragment_swap` — enables swap button on Express/Horizon canvas
- `GS-28940_Fragment_Swap_Extension` — enables extensions in dropdown